### PR TITLE
Use of inherited fields when mapping json objects

### DIFF
--- a/src/main/java/it/restrung/rest/marshalling/response/AbstractJSONResponse.java
+++ b/src/main/java/it/restrung/rest/marshalling/response/AbstractJSONResponse.java
@@ -55,7 +55,7 @@ public abstract class AbstractJSONResponse implements JSONResponse {
     public void fromJSON(JSONObject jsonObject) throws JSONException {
         if (jsonObject != null) {
             this.delegate = jsonObject;
-            Method[] methods = getClass().getDeclaredMethods();
+            Method[] methods = getClass().getMethods();
             for (Method method : methods) {
                 if (method.getParameterTypes().length == 1 && method.getName().startsWith("set") && method.getName().length() > 3) {
                     Class argType = method.getParameterTypes()[0];


### PR DESCRIPTION
Made use of inherited fields when mapping json objects, not just the declared fields.
