### PR TITLE
Support for existing query params in path

### DIFF
--- a/android-rest/src/instrumentTest/java/ly/apps/android/rest/tests/QueryParamsConverterTest.java
+++ b/android-rest/src/instrumentTest/java/ly/apps/android/rest/tests/QueryParamsConverterTest.java
@@ -76,4 +76,29 @@ public class QueryParamsConverterTest extends InstrumentationTestCase {
                 )
         );
     }
+
+    public void testParseQueryParamsWithExistingQueryParam() throws UnsupportedEncodingException {
+        assertEquals(
+                "/api/path/test?id=47&other=other",
+                converter.parseQueryParams(
+                        "/api/path/test?id=47",
+                        new LinkedHashMap<Integer, String>() {{
+                            put(0, "other");
+                        }}
+                        , new Object[]{ "other"}
+                )
+        );
+    }
+
+    public void testParseBundledQueryParamsWithExistingQueryParam() throws UnsupportedEncodingException {
+        assertEquals(
+                "/api/path/test?id=47&other=other",
+                converter.parseBundledQueryParams(
+                        "/api/path/test?id=47",
+                        new LinkedHashMap<String, String>() {{
+                            put("other", "other");
+                        }}
+                )
+        );
+    }
 }

--- a/android-rest/src/main/java/ly/apps/android/rest/converters/impl/JacksonQueryParamsConverter.java
+++ b/android-rest/src/main/java/ly/apps/android/rest/converters/impl/JacksonQueryParamsConverter.java
@@ -64,7 +64,7 @@ public class JacksonQueryParamsConverter implements QueryParamsConverter {
     @SuppressWarnings("unchecked")
     public String parseBundledQueryParams(String path, Object object) throws UnsupportedEncodingException {
         if (object != null) {
-            path = path.contains("?") ? path : path + "?";
+            path += path.contains("?") ? "&" : "?";
             Map<String,Object> props = mapper.convertValue(object, Map.class);
             List<String> vals = new ArrayList<String>();
             for (Map.Entry<String, Object> queryParamEntry : props.entrySet()) {
@@ -81,7 +81,7 @@ public class JacksonQueryParamsConverter implements QueryParamsConverter {
     @Override
     public String parseQueryParams(String path, Map<Integer, String> queryParams, Object[] args) throws UnsupportedEncodingException {
         if (queryParams.size() > 0) {
-            path = path.contains("?") ? path : path + "?";
+            path += path.contains("?") ? "&" : "?";
             List<String> vals = new ArrayList<String>();
             for (Map.Entry<Integer, String> queryParamEntry : queryParams.entrySet()) {
                 Object paramVal = args[queryParamEntry.getKey()];


### PR DESCRIPTION
If a path already contains a query params i.e. @GET(“/user?a=1”) and
additional params are included using @QueryParam then append the &
correctly.
